### PR TITLE
自分用キーマップの作成

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
@@ -24,38 +24,38 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   // keymap for futabooo (VIA)
   [0] = LAYOUT_universal(
-    KC_ESC   , KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                                        KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     , KC_DEL   ,
-    CTL_T(KC_TAB), KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                                        KC_H     , KC_J     , KC_K     , KC_L     , KC_SCLN  , S(KC_7)  ,
-    KC_LSFT      , KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     ,                                        KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  , KC_INT1  ,
-              KC_LALT , KC_LGUI ,    LC(2,KC_LNG2) , LT(1,KC_SPC) , LT(3,KC_LNG1) ,                  KC_BSPC , RCMD_T(KC_ENT) , RCTL_T(KC_LNG2),KC_RALT    , G(A(KC_SPC))
+    KC_ESC        , KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                                        KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     , KC_DEL   ,
+    CTL_T(KC_TAB) , KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                                        KC_H     , KC_J     , KC_K     , KC_L     , KC_SCLN  , KC_QUOT  ,
+    KC_LSFT       , KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     ,                                        KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  , KC_INT1  ,
+              KC_LALT , KC_LGUI ,    LC(2,KC_LNG2) , LT(1,KC_SPC) , LT(3,KC_LNG1) ,                   KC_BSPC  , RCMD_T(KC_ENT) ,       XXXXXXX  , XXXXXXX  , G(A(KC_SPC))
   ),
 
   [1] = LAYOUT_universal(
     KC_GRV   ,  KC_EXLM , KC_AT    , KC_HASH , KC_DLR   , KC_PERC  ,                                         KC_CIRC  , KC_AMPR  , KC_ASTR  , KC_LPRN  , KC_RPRN  , KC_MINS  ,
     XXXXXXX  ,  XXXXXXX , XXXXXXX  , XXXXXXX , XXXXXXX  , XXXXXXX  ,                                         XXXXXXX  , XXXXXXX  , KC_UP    , KC_LBRC  , KC_RBRC  , KC_EQL   ,
     KC_LSFT  ,  XXXXXXX , XXXXXXX  , XXXXXXX , XXXXXXX  , XXXXXXX  ,                                         XXXXXXX  , KC_LEFT  , KC_DOWN  , KC_RGHT  , XXXXXXX  , KC_BSLS  ,
-                  XXXXXXX  , XXXXXXX , XXXXXXX  ,         XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , XXXXXXX  , XXXXXXX       , XXXXXXX  , XXXXXXX
+                  XXXXXXX  , XXXXXXX  ,           XXXXXXX  ,  XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , XXXXXXX  ,        XXXXXXX  , XXXXXXX  , XXXXXXX
   ),
 
   [2] = LAYOUT_universal(
     XXXXXXX , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,                                         XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
     XXXXXXX , KC_1     , KC_2     , KC_3     , KC_4     , KC_5     ,                                         KC_6     , KC_7     , KC_8     , KC_9     , KC_0     , XXXXXXX  ,
     XXXXXXX , C(KC_1)  , C(KC_2)  , C(KC_3)  , C(KC_4)  , C(KC_5)  ,                                         XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
-                  XXXXXXX     , KC_DOT  , XXXXXXX  ,         XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , XXXXXXX  , XXXXXXX       , XXXXXXX  , XXXXXXX
+                  XXXXXXX  , KC_DOT  ,            XXXXXXX  ,  XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , XXXXXXX  ,        XXXXXXX  , XXXXXXX  , XXXXXXX
   ),
 
   [3] = LAYOUT_universal(
     XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,                                        XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
     XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , SCRL_DVI ,                                        XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
     KC_LSFT  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , SCRL_DVD ,                                        CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , XXXXXXX  , KBC_SAVE ,
-                  QK_BOOT    , KBC_RST  , XXXXXXX  ,        XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , XXXXXXX  , XXXXXXX       , KBC_RST  , QK_BOOT
+                  QK_BOOT  , KBC_RST  ,           XXXXXXX  ,  XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , XXXXXXX  ,        XXXXXXX  , XXXXXXX  , QK_BOOT
   ),
 
   [4] = LAYOUT_universal(
     XXXXXXX  ,  XXXXXXX , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,                                        XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
     XXXXXXX  ,  XXXXXXX , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,                                        XXXXXXX  , KC_BTN1  , KC_BTN2  , KC_BTN3  , XXXXXXX  , XXXXXXX  ,
-    XXXXXXX  ,  XXXXXXX , XXXXXXX  , XXXXXXX , XXXXXXX   , XXXXXXX  ,                                        XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
-                  XXXXXXX  , XXXXXXX , XXXXXXX  ,         XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , XXXXXXX  , XXXXXXX       , XXXXXXX  , XXXXXXX
+    XXXXXXX  ,  XXXXXXX , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,                                        XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
+                  XXXXXXX  , XXXXXXX ,            XXXXXXX  ,  XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , XXXXXXX  ,        XXXXXXX  , XXXXXXX  , XXXXXXX
   ),
 };
 // clang-format on

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
@@ -26,8 +26,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [0] = LAYOUT_universal(
     KC_ESC   , KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                                        KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     , KC_DEL   ,
     CTL_T(KC_TAB), KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                                        KC_H     , KC_J     , KC_K     , KC_L     , KC_SCLN  , S(KC_7)  ,
-    KC_LSFT  , KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     ,                                        KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  , KC_INT1  ,
-              KC_LALT,KC_LGUI,LCTL_T(KC_LNG2)     ,LT(1,KC_SPC),LT(3,KC_LNG1),                  KC_BSPC,LT(2,KC_ENT), RCTL_T(KC_LNG2),     KC_RALT  , KC_PSCR
+    KC_LSFT      , KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     ,                                        KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  , KC_INT1  ,
+              KC_LALT , KC_LGUI ,    LC(2,KC_LNG2) , LT(1,KC_SPC) , LT(3,KC_LNG1) ,                  KC_BSPC , RCMD_T(KC_ENT) , RCTL_T(KC_LNG2),KC_RALT    , KC_PSCR
   ),
 
   [1] = LAYOUT_universal(

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
@@ -31,31 +31,31 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   ),
 
   [1] = LAYOUT_universal(
-    _______  ,  KC_F1   , KC_F2    , KC_F3   , KC_F4    , KC_F5    ,                                         KC_F6    , KC_F7    , KC_F8    , KC_F9    , KC_F10   , KC_F11   ,
-    _______  ,  _______ , _______  , KC_UP   , KC_ENT   , KC_DEL   ,                                         KC_PGUP  , KC_BTN1  , KC_UP    , KC_BTN2  , KC_BTN3  , KC_F12   ,
-    _______  ,  _______ , KC_LEFT  , KC_DOWN , KC_RGHT  , KC_BSPC  ,                                         KC_PGDN  , KC_LEFT  , KC_DOWN  , KC_RGHT  , _______  , _______  ,
-                  _______  , _______ , _______  ,         _______  , _______  ,                   _______  , _______  , _______       , _______  , _______
+    XXXXXXX  ,  KC_F1   , KC_F2    , KC_F3   , KC_F4    , KC_F5    ,                                         KC_F6    , KC_F7    , KC_F8    , KC_F9    , KC_F10   , KC_F11   ,
+    XXXXXXX  ,  XXXXXXX , XXXXXXX  , KC_UP   , KC_ENT   , KC_DEL   ,                                         KC_PGUP  , KC_BTN1  , KC_UP    , KC_BTN2  , KC_BTN3  , KC_F12   ,
+    XXXXXXX  ,  XXXXXXX , KC_LEFT  , KC_DOWN , KC_RGHT  , KC_BSPC  ,                                         KC_PGDN  , KC_LEFT  , KC_DOWN  , KC_RGHT  , XXXXXXX  , XXXXXXX  ,
+                  XXXXXXX  , XXXXXXX , XXXXXXX  ,         XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , XXXXXXX  , XXXXXXX       , XXXXXXX  , XXXXXXX
   ),
 
   [2] = LAYOUT_universal(
-    _______  ,S(KC_QUOT), KC_7     , KC_8    , KC_9     , S(KC_8)  ,                                         S(KC_9)  , S(KC_1)  , S(KC_6)  , KC_LBRC  , S(KC_4)  , _______  ,
-    _______  ,S(KC_SCLN), KC_4     , KC_5    , KC_6     , KC_RBRC  ,                                         KC_NUHS  , KC_MINS  , S(KC_EQL), S(KC_3)  , KC_QUOT  , S(KC_2)  ,
-    _______  ,S(KC_MINS), KC_1     , KC_2    , KC_3     ,S(KC_RBRC),                                        S(KC_NUHS),S(KC_INT1), KC_EQL   ,S(KC_LBRC),S(KC_SLSH),S(KC_INT3),
-                  KC_0     , KC_DOT  , _______  ,         _______  , _______  ,                   KC_DEL   , _______  , _______       , _______  , _______
+    XXXXXXX  ,S(KC_QUOT), KC_7     , KC_8    , KC_9     , S(KC_8)  ,                                         S(KC_9)  , S(KC_1)  , S(KC_6)  , KC_LBRC  , S(KC_4)  , XXXXXXX  ,
+    XXXXXXX  ,S(KC_SCLN), KC_4     , KC_5    , KC_6     , KC_RBRC  ,                                         KC_NUHS  , KC_MINS  , S(KC_EQL), S(KC_3)  , KC_QUOT  , S(KC_2)  ,
+    XXXXXXX  ,S(KC_MINS), KC_1     , KC_2    , KC_3     ,S(KC_RBRC),                                        S(KC_NUHS),S(KC_INT1), KC_EQL   ,S(KC_LBRC),S(KC_SLSH),S(KC_INT3),
+                  KC_0     , KC_DOT  , XXXXXXX  ,         XXXXXXX  , XXXXXXX  ,                   KC_DEL   , XXXXXXX  , XXXXXXX       , XXXXXXX  , XXXXXXX
   ),
 
   [3] = LAYOUT_universal(
-    _______  , _______  , _______  , _______  , _______  , _______  ,                                        _______  , _______  , _______  , _______  , _______  , _______  ,
-    _______  , _______  , _______  , _______  , _______  , SCRL_DVI ,                                        _______  , _______  , _______  , _______  , _______  , _______  ,
-    KC_LSFT  , _______  , _______  , _______  , _______  , SCRL_DVD ,                                        CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , _______  , KBC_SAVE ,
-                  QK_BOOT    , KBC_RST  , _______  ,        _______  , _______  ,                   _______  , _______  , _______       , KBC_RST  , QK_BOOT
+    XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,                                        XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
+    XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , SCRL_DVI ,                                        XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
+    KC_LSFT  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , SCRL_DVD ,                                        CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , XXXXXXX  , KBC_SAVE ,
+                  QK_BOOT    , KBC_RST  , XXXXXXX  ,        XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , XXXXXXX  , XXXXXXX       , KBC_RST  , QK_BOOT
   ),
 
   [4] = LAYOUT_universal(
-    _______  ,  _______ , _______  , _______  , _______  , _______  ,                                        _______  , _______  , _______  , _______  , _______  , _______  ,
-    _______  ,  _______ , _______  , _______  , _______  , _______  ,                                        _______  , KC_BTN1  , KC_BTN2  , KC_BTN3  , _______  , _______  ,
-    _______  ,  _______ , _______  , _______ , _______   , _______  ,                                        _______  , _______  , _______  , _______  , _______  , _______  ,
-                  _______  , _______ , _______  ,         _______  , _______  ,                   _______  , _______  , _______       , _______  , _______
+    XXXXXXX  ,  XXXXXXX , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,                                        XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
+    XXXXXXX  ,  XXXXXXX , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,                                        XXXXXXX  , KC_BTN1  , KC_BTN2  , KC_BTN3  , XXXXXXX  , XXXXXXX  ,
+    XXXXXXX  ,  XXXXXXX , XXXXXXX  , XXXXXXX , XXXXXXX   , XXXXXXX  ,                                        XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
+                  XXXXXXX  , XXXXXXX , XXXXXXX  ,         XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , XXXXXXX  , XXXXXXX       , XXXXXXX  , XXXXXXX
   ),
 };
 // clang-format on

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
@@ -25,7 +25,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   // keymap for futabooo (VIA)
   [0] = LAYOUT_universal(
     KC_ESC   , KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                                        KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     , KC_DEL   ,
-    KC_TAB   , KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                                        KC_H     , KC_J     , KC_K     , KC_L     , KC_SCLN  , S(KC_7)  ,
+    CTL_T(KC_TAB), KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                                        KC_H     , KC_J     , KC_K     , KC_L     , KC_SCLN  , S(KC_7)  ,
     KC_LSFT  , KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     ,                                        KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  , KC_INT1  ,
               KC_LALT,KC_LGUI,LCTL_T(KC_LNG2)     ,LT(1,KC_SPC),LT(3,KC_LNG1),                  KC_BSPC,LT(2,KC_ENT), RCTL_T(KC_LNG2),     KC_RALT  , KC_PSCR
   ),

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
@@ -27,7 +27,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_ESC   , KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                                        KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     , KC_DEL   ,
     CTL_T(KC_TAB), KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                                        KC_H     , KC_J     , KC_K     , KC_L     , KC_SCLN  , S(KC_7)  ,
     KC_LSFT      , KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     ,                                        KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  , KC_INT1  ,
-              KC_LALT , KC_LGUI ,    LC(2,KC_LNG2) , LT(1,KC_SPC) , LT(3,KC_LNG1) ,                  KC_BSPC , RCMD_T(KC_ENT) , RCTL_T(KC_LNG2),KC_RALT    , KC_PSCR
+              KC_LALT , KC_LGUI ,    LC(2,KC_LNG2) , LT(1,KC_SPC) , LT(3,KC_LNG1) ,                  KC_BSPC , RCMD_T(KC_ENT) , RCTL_T(KC_LNG2),KC_RALT    , G(A(KC_SPC))
   ),
 
   [1] = LAYOUT_universal(

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
@@ -38,10 +38,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   ),
 
   [2] = LAYOUT_universal(
-    XXXXXXX  ,S(KC_QUOT), KC_7     , KC_8    , KC_9     , S(KC_8)  ,                                         S(KC_9)  , S(KC_1)  , S(KC_6)  , KC_LBRC  , S(KC_4)  , XXXXXXX  ,
-    XXXXXXX  ,S(KC_SCLN), KC_4     , KC_5    , KC_6     , KC_RBRC  ,                                         KC_NUHS  , KC_MINS  , S(KC_EQL), S(KC_3)  , KC_QUOT  , S(KC_2)  ,
-    XXXXXXX  ,S(KC_MINS), KC_1     , KC_2    , KC_3     ,S(KC_RBRC),                                        S(KC_NUHS),S(KC_INT1), KC_EQL   ,S(KC_LBRC),S(KC_SLSH),S(KC_INT3),
-                  KC_0     , KC_DOT  , XXXXXXX  ,         XXXXXXX  , XXXXXXX  ,                   KC_DEL   , XXXXXXX  , XXXXXXX       , XXXXXXX  , XXXXXXX
+    XXXXXXX , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,                                         XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
+    XXXXXXX , KC_1     , KC_2     , KC_3     , KC_4     , KC_5     ,                                         KC_6     , KC_7     , KC_8     , KC_9     , KC_0     , XXXXXXX  ,
+    XXXXXXX , C(KC_1)  , C(KC_2)  , C(KC_3)  , C(KC_4)  , C(KC_5)  ,                                         XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
+                  XXXXXXX     , KC_DOT  , XXXXXXX  ,         XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , XXXXXXX  , XXXXXXX       , XXXXXXX  , XXXXXXX
   ),
 
   [3] = LAYOUT_universal(

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
@@ -31,9 +31,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   ),
 
   [1] = LAYOUT_universal(
-    XXXXXXX  ,  KC_F1   , KC_F2    , KC_F3   , KC_F4    , KC_F5    ,                                         KC_F6    , KC_F7    , KC_F8    , KC_F9    , KC_F10   , KC_F11   ,
-    XXXXXXX  ,  XXXXXXX , XXXXXXX  , KC_UP   , KC_ENT   , KC_DEL   ,                                         KC_PGUP  , KC_BTN1  , KC_UP    , KC_BTN2  , KC_BTN3  , KC_F12   ,
-    XXXXXXX  ,  XXXXXXX , KC_LEFT  , KC_DOWN , KC_RGHT  , KC_BSPC  ,                                         KC_PGDN  , KC_LEFT  , KC_DOWN  , KC_RGHT  , XXXXXXX  , XXXXXXX  ,
+    KC_GRV   ,  KC_EXLM , KC_AT    , KC_HASH , KC_DLR   , KC_PERC  ,                                         KC_CIRC  , KC_AMPR  , KC_ASTR  , KC_LPRN  , KC_RPRN  , KC_MINS  ,
+    XXXXXXX  ,  XXXXXXX , XXXXXXX  , XXXXXXX , XXXXXXX  , XXXXXXX  ,                                         XXXXXXX  , XXXXXXX  , KC_UP    , KC_LBRC  , KC_RBRC  , KC_EQL   ,
+    KC_LSFT  ,  XXXXXXX , XXXXXXX  , XXXXXXX , XXXXXXX  , XXXXXXX  ,                                         XXXXXXX  , KC_LEFT  , KC_DOWN  , KC_RGHT  , XXXXXXX  , KC_BSLS  ,
                   XXXXXXX  , XXXXXXX , XXXXXXX  ,         XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , XXXXXXX  , XXXXXXX       , XXXXXXX  , XXXXXXX
   ),
 

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
@@ -27,7 +27,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_ESC        , KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                                        KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     , KC_DEL   ,
     CTL_T(KC_TAB) , KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                                        KC_H     , KC_J     , KC_K     , KC_L     , KC_SCLN  , KC_QUOT  ,
     KC_LSFT       , KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     ,                                        KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  , KC_INT1  ,
-              KC_LALT , KC_LGUI ,    LC(2,KC_LNG2) , LT(1,KC_SPC) , LT(3,KC_LNG1) ,                   KC_BSPC  , RCMD_T(KC_ENT) ,       XXXXXXX  , XXXXXXX  , G(A(KC_SPC))
+              KC_LALT , KC_LGUI ,    LT(2,KC_LNG2) , LT(1,KC_SPC) , LT(3,KC_LNG1) ,                   KC_BSPC  , RCMD_T(KC_ENT) ,       XXXXXXX  , XXXXXXX  , G(A(KC_SPC))
   ),
 
   [1] = LAYOUT_universal(


### PR DESCRIPTION
- 非透過キーを使う設定のところを何もしない設定にする
- ホールドでctrl、タップでtabにする
- Layer2への切り替えを左手親指へ、右手親指の長押しをcmdにする
- 右手小指でcmd+alt+spaceとする
- Layer1に標準USキーボードとだいたい同じ指で記号を配置
- Layer2に数字とmacで仮想Desctop切り替える用のキーを置く
- 右手トラックボールで使ってるのでkeymapのformatを調整
- fix typo
