### PR TITLE
modify keymap

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/futabooo/keymap.c
@@ -26,36 +26,36 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [0] = LAYOUT_universal(
     KC_ESC        , KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                                        KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     , KC_DEL   ,
     CTL_T(KC_TAB) , KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                                        KC_H     , KC_J     , KC_K     , KC_L     , KC_SCLN  , KC_QUOT  ,
-    KC_LSFT       , KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     ,                                        KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  , KC_INT1  ,
-              KC_LALT , KC_LGUI ,    LT(2,KC_LNG2) , LT(1,KC_SPC) , LT(3,KC_LNG1) ,                   KC_BSPC  , RCMD_T(KC_ENT) ,       XXXXXXX  , XXXXXXX  , G(A(KC_SPC))
+    KC_LSFT       , KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     ,                                        KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  , XXXXXXX  ,
+              KC_LALT , KC_LGUI ,    LT(2,KC_LNG2) , LT(1,KC_SPC) , LT(3,KC_LNG1) ,                   SFT_T(KC_BSPC)  , RCMD_T(KC_ENT) ,       XXXXXXX  , XXXXXXX  , G(A(KC_SPC))
   ),
 
   [1] = LAYOUT_universal(
-    KC_GRV   ,  KC_EXLM , KC_AT    , KC_HASH , KC_DLR   , KC_PERC  ,                                         KC_CIRC  , KC_AMPR  , KC_ASTR  , KC_LPRN  , KC_RPRN  , KC_MINS  ,
-    _______  ,  XXXXXXX , XXXXXXX  , XXXXXXX , XXXXXXX  , XXXXXXX  ,                                         XXXXXXX  , XXXXXXX  , KC_UP    , KC_LBRC  , KC_RBRC  , KC_EQL   ,
-    _______  ,  XXXXXXX , XXXXXXX  , XXXXXXX , XXXXXXX  , XXXXXXX  ,                                         XXXXXXX  , KC_LEFT  , KC_DOWN  , KC_RGHT  , XXXXXXX  , KC_BSLS  ,
-                  _______  , _______  ,           XXXXXXX  ,  XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , KC_RCMD  ,        XXXXXXX  , XXXXXXX  , _______
+    XXXXXXX          , KC_1     , KC_2     , KC_3       , KC_4     , KC_5     ,                                   KC_6     , KC_7     , KC_8        , KC_9        , KC_0       , XXXXXXX     ,
+    CTL_T(KC_GRV)    , KC_EXLM  , KC_AT    , KC_HASH    , KC_DLR   , KC_PERC  ,                                   KC_CIRC  , KC_AMPR  , KC_ASTR     , KC_MINS     , KC_EQL     , KC_BSLS     ,
+    SFT_T(S(KC_GRV)) , XXXXXXX  , XXXXXXX  , S(KC_LBRC) , KC_LBRC  , KC_LPRN  ,                                   KC_RPRN  , KC_RBRC  , S(KC_RBRC)  , S(KC_MINS)  , S(KC_EQL)  , S(KC_BSLS)  ,
+                  _______  , _______  ,           XXXXXXX  ,  XXXXXXX  , XXXXXXX  ,                   _______  , KC_RCMD  ,        XXXXXXX  , XXXXXXX  , _______
   ),
 
   [2] = LAYOUT_universal(
-    XXXXXXX , C(KC_1)  , C(KC_2)  , C(KC_3)  , C(KC_4)  , C(KC_5)  ,                                         XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
-    _______ , KC_1     , KC_2     , KC_3     , KC_4     , KC_5     ,                                         KC_6     , KC_7     , KC_8     , KC_9     , KC_0     , XXXXXXX  ,
-    _______ , XXXXXXX  , XXXXXXX  , XXXXXXX , XXXXXXX  , XXXXXXX   ,                                         XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
-                  _______  , _______  ,           XXXXXXX  ,  XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , _______  ,        XXXXXXX  , XXXXXXX  , _______
+    XXXXXXX , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,                                         XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
+    KC_LCTL , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,                                         XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
+    KC_LSFT , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,                                         XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
+                  _______  , _______  ,           XXXXXXX  ,  XXXXXXX  , XXXXXXX  ,                   _______  , _______  ,        XXXXXXX  , XXXXXXX  , _______
   ),
 
   [3] = LAYOUT_universal(
-    XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,                                        XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
-    _______  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , SCRL_DVI ,                                        XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
-    _______  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , SCRL_DVD ,                                        CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , XXXXXXX  , KBC_SAVE ,
-                  QK_BOOT  , KBC_RST  ,           XXXXXXX  ,  XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , _______  ,        XXXXXXX  , XXXXXXX  , _______
+    XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX   , XXXXXXX  ,                                        XXXXXXX  , XXXXXXX  , KC_UP    , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
+    _______  , XXXXXXX  , XXXXXXX  , XXXXXXX  , CPI_I100  , SCRL_DVI ,                                        XXXXXXX  , KC_LEFT  , KC_DOWN  , KC_RGHT  , XXXXXXX  , XXXXXXX  ,
+    _______  , XXXXXXX  , XXXXXXX  , XXXXXXX  , CPI_D100  , SCRL_DVD ,                                        XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , KBC_SAVE ,
+                  _______  , _______  ,           QK_BOOT  ,  KBC_RST  , XXXXXXX  ,                   _______  , _______  ,        XXXXXXX  , XXXXXXX  , _______
   ),
 
   [4] = LAYOUT_universal(
     XXXXXXX  ,  XXXXXXX , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,                                        XXXXXXX        , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
     _______  ,  XXXXXXX , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,                                        LCMD(KC_LBRC)  , KC_BTN1  , KC_BTN2  , KC_BTN3  , XXXXXXX  , XXXXXXX  ,
     _______  ,  XXXXXXX , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,                                        LCMD(KC_RBRC)  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  , XXXXXXX  ,
-                  XXXXXXX  , XXXXXXX ,            XXXXXXX  ,  XXXXXXX  , XXXXXXX  ,                   XXXXXXX  , XXXXXXX  ,        XXXXXXX  , XXXXXXX  , _______
+                  _______  , _______ ,            XXXXXXX  ,  XXXXXXX  , XXXXXXX  ,                   _______  , XXXXXXX  ,        XXXXXXX  , XXXXXXX  , _______
   ),
 };
 // clang-format on


### PR DESCRIPTION
## 変更点
- 記号のシフト同時押しで打てるキーをlayer1に配置
- 左手の英字の大文字が打ちにくかったので右手親指に長押しでシフトを配置
- かっこは右手の小指を動かすのがわからなくなってたので左右に始まりを終わりを配置して左手が始まり、右手が終わりというのを連想しやすいように配置
- 今まで左右はホームポジションから下げて押してた矢印キーはホームポジションにいる時に左右で動かせるように配置
- layer消すのは他の設定をいじらないといけないので覚えてられないからやらない